### PR TITLE
[consensus] fix message id for multisig

### DIFF
--- a/consensus/fbft_log.go
+++ b/consensus/fbft_log.go
@@ -75,7 +75,7 @@ type (
 
 var shaPool = sync.Pool{
 	New: func() interface{} {
-		return sha3.NewLegacyKeccak256()
+		return sha3.New256()
 	},
 }
 

--- a/consensus/fbft_log.go
+++ b/consensus/fbft_log.go
@@ -6,12 +6,11 @@ import (
 	"hash"
 	"sync"
 
-	"golang.org/x/crypto/sha3"
-
 	"github.com/ethereum/go-ethereum/common"
 	bls_core "github.com/harmony-one/bls/ffi/go/bls"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
+	"golang.org/x/crypto/sha3"
 
 	msg_pb "github.com/harmony-one/harmony/api/proto/message"
 	"github.com/harmony-one/harmony/core/types"

--- a/consensus/fbft_log_test.go
+++ b/consensus/fbft_log_test.go
@@ -41,6 +41,25 @@ func TestFBFTLog_id(t *testing.T) {
 	}
 }
 
+func BenchmarkFBFGLog_id(b *testing.B) {
+	msg := FBFTMessage{
+		MessageType: msg_pb.MessageType_ANNOUNCE,
+		BlockHash:   [32]byte{01, 02},
+		SenderPubkeys: []*bls.PublicKeyWrapper{
+			{
+				Bytes: bls.SerializedPublicKey{0x01, 0x02},
+			},
+			{
+				Bytes: bls.SerializedPublicKey{0x02, 0x04},
+			},
+		},
+	}
+
+	for i := 0; i < b.N; i++ {
+		msg.id()
+	}
+}
+
 func TestGetMessagesByTypeSeqViewHash(t *testing.T) {
 	pbftMsg := FBFTMessage{
 		MessageType: msg_pb.MessageType_ANNOUNCE,


### PR DESCRIPTION
## Issue

Add the id for new fbft message.

## Benchmark

```
goos: darwin
goarch: amd64
pkg: github.com/harmony-one/harmony/consensus
BenchmarkFBFGLog_id-12           1560042               783 ns/op
PASS
ok      github.com/harmony-one/harmony/consensus        4.454s
```

Benchmark running on macos machine gives <1ms per operation.